### PR TITLE
Prevent deprecation warning in webpack4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const loaderUtils = require('loader-utils');
 function cleanupLoader(source) {
   this.raw = true;
   const {test} = loaderUtils.getOptions(this);
-  this._compiler.plugin('emit', cleanupUnwantedJsFiles(test));
+  this._compiler.hooks.done.tap('emit', (test) => cleanupUnwantedJsFiles(test));
   this.callback(null, source);
 }
 


### PR DESCRIPTION
Using the cleanup-loader with webpack4 outputs a deprecation warning:
DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead